### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       SSP_VERSION: ${{ steps.determine_ssp_version.outputs.SSP_VERSION }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/smeetsee/docker-simplesamlphp/security/code-scanning/1](https://github.com/smeetsee/docker-simplesamlphp/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `prepare` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the job does not interact with the repository or external services, it likely only requires `contents: read` permissions. This change ensures that the job operates with the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
