### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -200,6 +200,9 @@ jobs:
     needs: [docker, prepare]
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      packages: write
     env:
       SSP_VERSION: ${{ needs.prepare.outputs.SSP_VERSION }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/smeetsee/docker-simplesamlphp/security/code-scanning/2](https://github.com/smeetsee/docker-simplesamlphp/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `merge` job. This block will explicitly define the minimal permissions required for the job to function correctly. Based on the job's steps, it interacts with Docker registries and fetches data from external APIs, so it likely requires `contents: read` and `packages: write`. These permissions will be explicitly set to ensure the job operates securely without inheriting overly permissive defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
